### PR TITLE
feat(engines v3 python): api template modification

### DIFF
--- a/languages/python/templates/api.mustache
+++ b/languages/python/templates/api.mustache
@@ -1,4 +1,5 @@
-{{! This file is picked from the v5.1.0 release of openapi-generator(https://github.com/OpenAPITools/openapi-generator/blob/v5.1.0/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache) }}
+{{! This file is picked from the v5.1.0 release of openapi-generator(https://github.com/OpenAPITools/openapi-generator/blob/v5.1.0/modules/openapi-generator/src/main/resources/python/api.mustache) }}
+{{! Changes made: 1) Updated returns section in the documentation of each method. 2) Added way to express multiple success scenarios that can return different response types. }}
 
 {{>partial_header}}
 
@@ -98,7 +99,7 @@ class {{classname}}(object):
                 async_req (bool): execute request asynchronously
 
             Returns:
-                {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}None{{/returnType}}
+                {{#vendorExtensions.x-are-multiple-success-responses-different}}{{#vendorExtensions.x-success-response-types}}(For {{status-code}} status - {{#response-type}}{{{response-type}}}{{/response-type}}{{^response-type}}{{#is-file}}File{{/is-file}}{{^is-file}}None{{/is-file}}{{/response-type}}){{/vendorExtensions.x-success-response-types}}{{/vendorExtensions.x-are-multiple-success-responses-different}}{{^vendorExtensions.x-are-multiple-success-responses-different}}{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}None{{/returnType}}{{/vendorExtensions.x-are-multiple-success-responses-different}}
                     If the method is called asynchronously, returns the request
                     thread.
             """
@@ -129,7 +130,7 @@ class {{classname}}(object):
 
         self.{{operationId}} = _Endpoint(
             settings={
-                'response_type': {{#returnType}}({{{returnType}}},){{/returnType}}{{^returnType}}None{{/returnType}},
+                'response_type': {{#returnType}}({{#vendorExtensions.x-are-multiple-success-responses-different}}{{#vendorExtensions.x-success-response-types}}{{#response-type}}{{{response-type}}}{{/response-type}}, {{/vendorExtensions.x-success-response-types}}{{/vendorExtensions.x-are-multiple-success-responses-different}}{{^vendorExtensions.x-are-multiple-success-responses-different}}{{#returnType}}{{{returnType}}}{{/returnType}}, {{/vendorExtensions.x-are-multiple-success-responses-different}}){{/returnType}}{{^returnType}}None{{/returnType}},
 {{#authMethods}}
 {{#-first}}
                 'auth': [

--- a/languages/python/templates/api_client.mustache
+++ b/languages/python/templates/api_client.mustache
@@ -1092,7 +1092,7 @@ class Endpoint(object):
                 content_type_headers_list)
             params['header']['Content-Type'] = header_list
 
-        return self.api_client.call_api(
+        return self.api_client.call_api_with_return_dict(
             self.settings['endpoint_path'], self.settings['http_method'],
             params['path'],
             params['query'],


### PR DESCRIPTION
What the resulting return documentation section looks like
```
Returns:
    (For 202 status - CalculationStatusRoot)(For 201 status - ObjectRoot)(For 200 status - CalculationStatusRoot)
        If the method is called asynchronously, returns the request
        thread.
```
```
'response_type': { 202:CalculationStatusRoot, 201:ObjectRoot, 200:CalculationStatusRoot,  }
```