### PR TITLE
fix(command-update): Replacing hub command with gh command

### DIFF
--- a/.github/scripts/raise-pull-request.sh
+++ b/.github/scripts/raise-pull-request.sh
@@ -38,7 +38,8 @@ then
     export GITHUB_USER=$USER
     export GITHUB_TOKEN=$USER_API_KEY
     #hub pull-request -m "feat(sdk): Auto-created from '$generator_repo_name' repository PR $pr_number for SDK version v$version" -h $branch_name
-    gh pr create "feat(sdk): Auto-created from '$generator_repo_name' repository PR $pr_number for SDK version v$version" --head $branch_name
+    gh pr create -m "feat(sdk): Auto-created from '$generator_repo_name' repository PR $pr_number for SDK version v$version" --H $branch_name
+    
   else
     echo "No changes to commit" 
   fi

--- a/.github/scripts/raise-pull-request.sh
+++ b/.github/scripts/raise-pull-request.sh
@@ -37,7 +37,8 @@ then
     
     export GITHUB_USER=$USER
     export GITHUB_TOKEN=$USER_API_KEY
-    hub pull-request -m "feat(sdk): Auto-created from '$generator_repo_name' repository PR $pr_number for SDK version v$version" -h $branch_name
+    #hub pull-request -m "feat(sdk): Auto-created from '$generator_repo_name' repository PR $pr_number for SDK version v$version" -h $branch_name
+    gh pr create "feat(sdk): Auto-created from '$generator_repo_name' repository PR $pr_number for SDK version v$version" --head $branch_name
   else
     echo "No changes to commit" 
   fi


### PR DESCRIPTION
Description: Since "**hub pull-request**" command to create pull request is deprecated and no longer supported from GitHub. Now it was recommended to use the "**gh pr create**" command to raise pull request to a repo. This decision was made based on the comments from release infrastructure team.

Error:
https://github.com/factset/analyticsapi-engines-sdk-generator/actions/runs/7900814917/job/21601637427#step:5:54

Reference:
https://github.com/actions/runner-images/issues/8362

![image](https://github.com/factset/analyticsapi-engines-sdk-generator/assets/4880029/8d877954-6097-4e5a-bf54-475ae307e21e)

![image](https://github.com/factset/analyticsapi-engines-sdk-generator/assets/4880029/dfe720b1-efdf-4451-8bd9-ae1cb47ba192)
