### PR TITLE
fix(sdks): Updated Stach Extensions version to latest in java SDK

### DIFF
--- a/languages/java/openapi-generator-config.json
+++ b/languages/java/openapi-generator-config.json
@@ -4,7 +4,7 @@
     "invokerPackage": "factset.analyticsapi.engines",
     "groupId": "com.factset.analyticsapi",
     "artifactId": "engines-sdk",
-    "artifactVersion": "6.0.0",
+    "artifactVersion": "6.1.0",
     "artifactUrl": "https://github.com/factset/analyticsapi-engines-java-sdk",
     "artifactDescription": "SDK for FactSet Analytics Engines API",
     "scmConnection": "scm:git:git://github.com/factset/analyticsapi-engines-java-sdk.git",
@@ -24,5 +24,5 @@
     "caseInsensitiveResponseHeaders": true,
     "library": "jersey2",
     "servers":  false,
-    "httpUserAgent": "engines-api/6.0.0/java"
+    "httpUserAgent": "engines-api/6.1.0/java"
 }

--- a/languages/java/templates/pom.mustache
+++ b/languages/java/templates/pom.mustache
@@ -253,18 +253,10 @@
             <version>${swagger-annotations-version}</version>
         </dependency>
 
-<!--        <dependency>-->
-<!--            <groupId>com.factset.protobuf</groupId>-->
-<!--            <artifactId>stachextensions</artifactId>-->
-<!--            <version>${stach-extensions-version}</version>-->
-<!--        </dependency>-->
-
         <dependency>
-            <scope>system</scope>
-            <systemPath>C:/Users/jmiriyala02/Downloads/stachextensions-1.5.0.jar</systemPath>
             <groupId>com.factset.protobuf</groupId>
             <artifactId>stachextensions</artifactId>
-            <version>1.5.0</version>
+            <version>${stach-extensions-version}</version>
         </dependency>
 
         <!-- @Nullable annotation -->
@@ -401,10 +393,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.1</swagger-annotations-version>
-        <stach-extensions-version>1.4.0</stach-extensions-version>
+        <stach-extensions-version>1.5.0</stach-extensions-version>
         <jersey-version>2.30.1</jersey-version>
-        <jackson-version>2.10.5</jackson-version>
-        <jackson-databind-version>2.12.7.1</jackson-databind-version>
+        <jackson-version>2.13.5</jackson-version>
+        <jackson-databind-version>2.13.5</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         {{#threetenbp}}
         <threetenbp-version>2.9.10</threetenbp-version>

--- a/languages/java/templates/pom.mustache
+++ b/languages/java/templates/pom.mustache
@@ -253,10 +253,18 @@
             <version>${swagger-annotations-version}</version>
         </dependency>
 
+<!--        <dependency>-->
+<!--            <groupId>com.factset.protobuf</groupId>-->
+<!--            <artifactId>stachextensions</artifactId>-->
+<!--            <version>${stach-extensions-version}</version>-->
+<!--        </dependency>-->
+
         <dependency>
+            <scope>system</scope>
+            <systemPath>C:/Users/jmiriyala02/Downloads/stachextensions-1.5.0.jar</systemPath>
             <groupId>com.factset.protobuf</groupId>
             <artifactId>stachextensions</artifactId>
-            <version>${stach-extensions-version}</version>
+            <version>1.5.0</version>
         </dependency>
 
         <!-- @Nullable annotation -->
@@ -393,10 +401,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.1</swagger-annotations-version>
-        <stach-extensions-version>1.1.1</stach-extensions-version>
+        <stach-extensions-version>1.4.0</stach-extensions-version>
         <jersey-version>2.30.1</jersey-version>
         <jackson-version>2.10.5</jackson-version>
-        <jackson-databind-version>2.10.5.1</jackson-databind-version>
+        <jackson-databind-version>2.12.7.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         {{#threetenbp}}
         <threetenbp-version>2.9.10</threetenbp-version>


### PR DESCRIPTION
Incremented the Java sdk version to 6.1.0

Upgraded stach-extensions version to latest
Upgarded jackson-databind version to 2.12.7.1