### PR TITLE
fix(command-update): Fixed command in Raising Pull Request Workflow

### DIFF
--- a/.github/scripts/raise-pull-request.sh
+++ b/.github/scripts/raise-pull-request.sh
@@ -38,7 +38,7 @@ then
     export GITHUB_USER=$USER
     export GITHUB_TOKEN=$USER_API_KEY
     #hub pull-request -m "feat(sdk): Auto-created from '$generator_repo_name' repository PR $pr_number for SDK version v$version" -h $branch_name
-    gh pr create -m "feat(sdk): Auto-created from '$generator_repo_name' repository PR $pr_number for SDK version v$version" --H $branch_name
+    gh pr create -m "feat(sdk): Auto-created from '$generator_repo_name' repository PR $pr_number for SDK version v$version" -H $branch_name
     
   else
     echo "No changes to commit" 


### PR DESCRIPTION
The command to raise Pull request is not set properly, hence it couldn't able to raise PR's automatically in SDK repos. 
Removed the extra '-' from '--H' and made it to '-H'

![image](https://github.com/user-attachments/assets/274e5c46-34fb-4afc-a0e9-2e710e92f619)
