### PR TITLE
fix(sdk): Updated stach extensions, jackson versions

### DIFF
--- a/languages/java/openapi-generator-config.json
+++ b/languages/java/openapi-generator-config.json
@@ -4,7 +4,7 @@
     "invokerPackage": "factset.analyticsapi.engines",
     "groupId": "com.factset.analyticsapi",
     "artifactId": "engines-sdk",
-    "artifactVersion": "6.0.0",
+    "artifactVersion": "6.1.0",
     "artifactUrl": "https://github.com/factset/analyticsapi-engines-java-sdk",
     "artifactDescription": "SDK for FactSet Analytics Engines API",
     "scmConnection": "scm:git:git://github.com/factset/analyticsapi-engines-java-sdk.git",
@@ -24,5 +24,5 @@
     "caseInsensitiveResponseHeaders": true,
     "library": "jersey2",
     "servers":  false,
-    "httpUserAgent": "engines-api/6.0.0/java"
+    "httpUserAgent": "engines-api/6.1.0/java"
 }

--- a/languages/java/templates/pom.mustache
+++ b/languages/java/templates/pom.mustache
@@ -393,10 +393,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.1</swagger-annotations-version>
-        <stach-extensions-version>1.1.1</stach-extensions-version>
+        <stach-extensions-version>1.5.0</stach-extensions-version>
         <jersey-version>2.30.1</jersey-version>
-        <jackson-version>2.10.5</jackson-version>
-        <jackson-databind-version>2.10.5.1</jackson-databind-version>
+        <jackson-version>2.13.5</jackson-version>
+        <jackson-databind-version>2.13.5</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         {{#threetenbp}}
         <threetenbp-version>2.9.10</threetenbp-version>


### PR DESCRIPTION
Incremented the Java sdk version to 6.1.0

Upgraded stach-extensions version to latest(1.5.0)
Upgarded jackson-databind,jackson-core version to 2.13.5