### PR TITLE
fix(sdk): Updated jersey package to remove snyk vulnerability

### DIFF
--- a/languages/java/openapi-generator-config.json
+++ b/languages/java/openapi-generator-config.json
@@ -4,7 +4,7 @@
     "invokerPackage": "factset.analyticsapi.engines",
     "groupId": "com.factset.analyticsapi",
     "artifactId": "engines-sdk",
-    "artifactVersion": "6.1.0",
+    "artifactVersion": "6.2.0",
     "artifactUrl": "https://github.com/factset/analyticsapi-engines-java-sdk",
     "artifactDescription": "SDK for FactSet Analytics Engines API",
     "scmConnection": "scm:git:git://github.com/factset/analyticsapi-engines-java-sdk.git",
@@ -24,5 +24,5 @@
     "caseInsensitiveResponseHeaders": true,
     "library": "jersey2",
     "servers":  false,
-    "httpUserAgent": "engines-api/6.1.0/java"
+    "httpUserAgent": "engines-api/6.2.0/java"
 }

--- a/languages/java/templates/pom.mustache
+++ b/languages/java/templates/pom.mustache
@@ -393,7 +393,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.1</swagger-annotations-version>
-        <stach-extensions-version>1.5.0</stach-extensions-version>
+        <stach-extensions-version>1.6.0</stach-extensions-version>
         <jersey-version>2.34</jersey-version>
         <jackson-version>2.13.5</jackson-version>
         <jackson-databind-version>2.13.5</jackson-databind-version>

--- a/languages/java/templates/pom.mustache
+++ b/languages/java/templates/pom.mustache
@@ -394,7 +394,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.1</swagger-annotations-version>
         <stach-extensions-version>1.5.0</stach-extensions-version>
-        <jersey-version>2.30.1</jersey-version>
+        <jersey-version>2.34</jersey-version>
         <jackson-version>2.13.5</jackson-version>
         <jackson-databind-version>2.13.5</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>


### PR DESCRIPTION
Upgraded the version to below packages to be 2.34 to remove snyk vulnerability

org.glassfish.jersey.core:jersey-client
org.glassfish.jersey.inject:jersey-hk2
org.glassfish.jersey.media:jersey-media-multipart
org.glassfish.jersey.media:jersey-media-json-jackson
org.glassfish.jersey.media:jersey-media-jaxb
org.glassfish.jersey.connectors:jersey-apache-connector


Incremented the minor version of SDK - latest now is 6.2.0






